### PR TITLE
wrapper around colorcolumn

### DIFF
--- a/plugin/superman.vim
+++ b/plugin/superman.vim
@@ -35,7 +35,9 @@ function! superman#SuperMan(...)
   setlocal softtabstop=8
   setlocal shiftwidth=8
   setlocal nolist
-  setlocal colorcolumn=0
+  if exists('+colorcolumn')
+    setlocal colorcolumn=0
+  endif
 
   " To make us behave more like less
   noremap q :q<CR>


### PR DESCRIPTION
vim on Andrew Unix is version 7.2, but colorcolumn is a version 7.3 feature.  This wrapper prevents the error.