### PR TITLE
Improved vman() shell function

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ whatever file you use to configure your shell:
 
 ```bash
 vman() {
-  vim -c "SuperMan $*"
+  man -d $* 2> /dev/null > /dev/null
 
   if [ "$?" != "0" ]; then
     echo "No manual entry for $*"
   fi
+
+  vim -c "SuperMan $*"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ vman() {
 
   if [ "$?" != "0" ]; then
     echo "No manual entry for $*"
+    return
   fi
 
   vim -c "SuperMan $*"


### PR DESCRIPTION
This version of `vman()` checks to see if the requested man page exists before trying to launch superman.

This makes trying to look up a man page that doesn't exist faster and less visually jarring.

This PR assumes that `man` takes a superset of the arguments to `-c Superman`, which I'm not sure is the case. It appears to work with both 'vman 3 printf` and `vman printf`, although perhaps there are other forms which I don't know about.

PS Thanks for superman, it's rad!