### PR TITLE
allow overriding editor name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 .*.swp
 tags

--- a/bin/vman
+++ b/bin/vman
@@ -9,4 +9,4 @@ elif ! man -d "$@" &> /dev/null; then
   exit 1
 fi
 
-vim -c "SuperMan $*"
+${EDITOR:-vim} -c "SuperMan $*"


### PR DESCRIPTION
vim-superman is such an awesome plugin ... truly revolutionary.

however, [neovim](https://github.com/neovim/neovim) name their executable `nvim`, so I thought it'd be nice if one can configure which vim executable to use in vim-superman.