### PR TITLE
get rid of setlocal number

### DIFF
--- a/plugin/superman.vim
+++ b/plugin/superman.vim
@@ -28,8 +28,6 @@ function! superman#SuperMan(...)
   setlocal readonly
   setlocal nomodifiable
 
-  setlocal number
-
   setlocal noexpandtab
   setlocal tabstop=8
   setlocal softtabstop=8


### PR DESCRIPTION
I always love the idea of displaying pure text and nothing else inside vim, so beautiful and elegant. And I'm always questioning the necessities and practical uses of displaying line numbers: it's only useful when you're trying to navigate to a specific line, but cannot help you with navigations any further.

People will probably always end up using something like [easymotion](https://github.com/easymotion/vim-easymotion) to help navigate to the exact position of interest. And once they get used to the system, line numbers are pretty much a waste of screen spaces. And they'll inevitably want to get rid of them.

I tried putting `autocmd FileType man setlocal nonumber` in my vimrc, but it didn't seem to work, that's why I'm making this proposal to remove this configuration from the plugin itself, and just let user control how they want to display their man pages.