### PR TITLE
Improve q mapping

### DIFF
--- a/plugin/superman.vim
+++ b/plugin/superman.vim
@@ -38,7 +38,7 @@ function! superman#SuperMan(...)
   endif
 
   " To make us behave more like less
-  noremap q :q<CR>
+  nnoremap <buffer> q :q<CR>
 endfunction
 
 " Command alias for our function


### PR DESCRIPTION
The mapping didn't seem to work for me, because another buffer-local mapping overrides it in vim's runtime files:
```
nnoremap <buffer> <silent> q :q<CR>
```
This is almost the same as my proposed change. However, in neovim, the command is more complicated and actually uses `:close`, which doesn't close the window if it's the last one and that is kind of annoying, if you don't want to continue using vim after reading the man page. On the other hand, if you don't intent to support neovim, this line might as well be deleted, because it does nothing (the buffer-local mapping takes precedence anyway).