### PR TITLE
Fix manpage existence check

### DIFF
--- a/bin/vman
+++ b/bin/vman
@@ -3,7 +3,7 @@
 if [ $# -eq 0 ]; then
   echo "What manual page do you want?";
   exit 0
-elif ! man -d "$@" &> /dev/null; then
+elif ! man -w "$@" &> /dev/null; then
   # Check that manpage exists to prevent visual noise.
   echo "No manual entry for $*"
   exit 1


### PR DESCRIPTION
On my machine, the `man -d` command returns 1 even when a manpage exists, causing vman to always print the 'No manual entry for <foo>' message.

The fix is to use the `man -w` command instead, which prints the path to the manpage if it exists, and also correctly sets the status code.